### PR TITLE
Scrape Karnataka department data for policy initialization

### DIFF
--- a/src/main/java/com/springvjpa/demo/config/DepartmentScraperClient.java
+++ b/src/main/java/com/springvjpa/demo/config/DepartmentScraperClient.java
@@ -1,0 +1,128 @@
+package com.springvjpa.demo.config;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DepartmentScraperClient {
+
+    private static final Logger log = LoggerFactory.getLogger(DepartmentScraperClient.class);
+    private static final Pattern ANCHOR_PATTERN = Pattern.compile("<a[^>]*href=\\\"([^\\\"]+)\\\"[^>]*>(.*?)</a>", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    private final HttpClient httpClient;
+    private final String departmentPageUrl;
+
+    public DepartmentScraperClient(
+            @Value("${app.department-source-url:https://mahitikanaja.karnataka.gov.in/Department}") String departmentPageUrl
+    ) {
+        this.httpClient = HttpClient.newBuilder()
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .connectTimeout(Duration.ofSeconds(20))
+                .build();
+        this.departmentPageUrl = departmentPageUrl;
+    }
+
+    public List<ScrapedDepartment> fetchTargetDepartments() {
+        try {
+            String html = fetchHtml();
+            List<ScrapedDepartment> departments = parseDepartments(html);
+            if (!departments.isEmpty()) {
+                return departments;
+            }
+            log.warn("No target departments were found in source page. Falling back to default targets.");
+        } catch (Exception ex) {
+            log.warn("Unable to scrape departments from {}. Falling back to defaults.", departmentPageUrl, ex);
+        }
+        return fallbackDepartments();
+    }
+
+    private String fetchHtml() throws IOException, InterruptedException {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(departmentPageUrl))
+                .GET()
+                .header("User-Agent", "Mozilla/5.0 (Spring-JPA Department Scraper)")
+                .timeout(Duration.ofSeconds(30))
+                .build();
+
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() >= 400) {
+            throw new IOException("Received HTTP " + response.statusCode() + " from " + departmentPageUrl);
+        }
+
+        return response.body();
+    }
+
+    private List<ScrapedDepartment> parseDepartments(String html) {
+        Map<String, ScrapedDepartment> results = new LinkedHashMap<>();
+        Matcher matcher = ANCHOR_PATTERN.matcher(html);
+
+        while (matcher.find()) {
+            String href = matcher.group(1).trim();
+            String text = stripTags(matcher.group(2)).trim();
+            String normalizedText = text.toLowerCase(Locale.ROOT);
+
+            if (normalizedText.contains("revenue") || normalizedText.contains("urban development")) {
+                String absoluteUrl = resolveUrl(href);
+                results.putIfAbsent(text, new ScrapedDepartment(text, absoluteUrl));
+            }
+        }
+
+        if (results.isEmpty()) {
+            captureFromPageBody(html, results);
+        }
+
+        return new ArrayList<>(results.values());
+    }
+
+    private void captureFromPageBody(String html, Map<String, ScrapedDepartment> results) {
+        String pageText = stripTags(html).toLowerCase(Locale.ROOT);
+        if (pageText.contains("department of revenue") || pageText.contains(" revenue ")) {
+            results.putIfAbsent("Department of Revenue", new ScrapedDepartment("Department of Revenue", departmentPageUrl));
+        }
+        if (pageText.contains("department of urban development") || pageText.contains(" urban development ")) {
+            results.putIfAbsent("Department of Urban Development", new ScrapedDepartment("Department of Urban Development", departmentPageUrl));
+        }
+    }
+
+    private String stripTags(String input) {
+        return input.replaceAll("<[^>]+>", " ").replaceAll("\\s+", " ");
+    }
+
+    private String resolveUrl(String href) {
+        try {
+            URI hrefUri = new URI(href);
+            if (hrefUri.isAbsolute()) {
+                return hrefUri.toString();
+            }
+            return URI.create(departmentPageUrl).resolve(hrefUri).toString();
+        } catch (URISyntaxException ex) {
+            return departmentPageUrl;
+        }
+    }
+
+    private List<ScrapedDepartment> fallbackDepartments() {
+        return List.of(
+                new ScrapedDepartment("Department of Revenue", departmentPageUrl),
+                new ScrapedDepartment("Department of Urban Development", departmentPageUrl)
+        );
+    }
+
+    public record ScrapedDepartment(String name, String sourceUrl) {
+    }
+}

--- a/src/test/java/com/springvjpa/demo/policy/api/PolicyControllerIntegrationTest.java
+++ b/src/test/java/com/springvjpa/demo/policy/api/PolicyControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDate;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -20,10 +21,10 @@ class PolicyControllerIntegrationTest {
     @Test
     void shouldReturnPoliciesFilteredByYearAndStatus() throws Exception {
         mockMvc.perform(get("/api/policies")
-                        .queryParam("year", "2024")
+                        .queryParam("year", String.valueOf(LocalDate.now().getYear()))
                         .queryParam("status", "NEEDS_REVIEW"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].department").value("Education"))
+                .andExpect(jsonPath("$[0].department").value(org.hamcrest.Matchers.containsStringIgnoringCase("revenue")))
                 .andExpect(jsonPath("$[0].validationStatus").value("NEEDS_REVIEW"));
     }
 


### PR DESCRIPTION
### Motivation
- Replace static seed data with live department listings so seeded policies reflect the latest information from the Karnataka Mahiti Kanaja Department page.
- Preferably target the Revenue and Department of Urban Development entries for generated policies and validations.

### Description
- Add `DepartmentScraperClient` which uses `java.net.http.HttpClient` to fetch the department listing page, parse anchor tags, resolve relative URLs, and extract entries that reference "revenue" or "urban development", with resilient fallback behavior when scraping fails. 
- Update `DataInitializer` to call `DepartmentScraperClient.fetchTargetDepartments()` and generate `Policy`, `LawReference`, and `ValidationResult` records from the scraped results instead of using hard-coded sample policies. 
- Update `PolicyControllerIntegrationTest` to expect current-year seeded data and to assert that a `NEEDS_REVIEW` entry exists for revenue-related departments.

### Testing
- Attempted direct fetch with `curl` to `https://mahitikanaja.karnataka.gov.in/Department` from the environment returned an upstream `503`/timeout, so fallback logic is intentionally present and exercised. 
- Ran the project tests with `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 PATH=$JAVA_HOME/bin:$PATH ./gradlew test`, and the build completed successfully with tests passing (including `PolicyControllerIntegrationTest` and `DemoApplicationTests`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e4c419bc832aafbfff34b66a185b)