### PR TITLE
Add production-ready async scraper for Mahiti Kanaja portal

### DIFF
--- a/python_scraper/.env.example
+++ b/python_scraper/.env.example
@@ -1,0 +1,7 @@
+BASE_URL=https://mahitikanaja.karnataka.gov.in
+HEADLESS=true
+REQUEST_TIMEOUT=30
+MAX_RETRIES=3
+RETRY_BACKOFF_SECONDS=1.5
+RATE_LIMIT_PER_SECOND=2.0
+USER_AGENT_FILE=user_agents.txt

--- a/python_scraper/Dockerfile
+++ b/python_scraper/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt && playwright install --with-deps chromium
+
+COPY src ./src
+COPY .env.example ./.env
+
+ENV PYTHONPATH=/app/src
+CMD ["python", "-m", "mahitikanaja_scraper.cli", "--headless", "--output-format", "both"]

--- a/python_scraper/README.md
+++ b/python_scraper/README.md
@@ -1,0 +1,90 @@
+# Mahiti Kanaja Playwright Scraper
+
+Production-oriented async scraper for https://mahitikanaja.karnataka.gov.in.
+
+## Features
+- Async Playwright navigation for SPA content and dropdown handling.
+- Network/API discovery: records API-like responses and tries JSON endpoints first.
+- `httpx` direct API fallback path with retries and exponential-style backoff.
+- Robots.txt compliance check before scraping.
+- Rate limiting and user-agent rotation.
+- Resume support with `resume_state.json`.
+- Parallel district/taluka expansion with semaphore control.
+- Data deduplication (in-memory + SQLite unique constraints).
+- JSON/CSV outputs and optional SQLite persistence.
+- Structured logging.
+- CLI filtering by department and district.
+
+## Project structure
+
+```text
+python_scraper/
+  src/mahitikanaja_scraper/
+    cli.py
+    config.py
+    scraper.py
+    browser_client.py
+    api_client.py
+    parser.py
+    storage.py
+    state.py
+    ua.py
+    rate_limiter.py
+    models.py
+    logging_config.py
+  requirements.txt
+  .env.example
+  Dockerfile
+  user_agents.txt
+```
+
+## Setup
+
+```bash
+cd python_scraper
+python3.11 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+playwright install chromium
+cp .env.example .env
+```
+
+## Run
+
+```bash
+PYTHONPATH=src python -m mahitikanaja_scraper.cli --headless --output-format both
+```
+
+Optional filters:
+
+```bash
+PYTHONPATH=src python -m mahitikanaja_scraper.cli --department "Agriculture" --district "Bengaluru" --output-format json
+```
+
+## Output layout
+
+```text
+data/
+  <department_name>/
+    <scheme_name>.json
+    <scheme_name>.csv
+  schemes.db
+  api_hints.jsonl
+  resume_state.json
+  run_config.json
+```
+
+## Dynamic DOM handling notes
+- The scraper uses `wait_for_load_state("networkidle")` before querying cards and links.
+- It probes multiple selector patterns (`.scheme-card a`, URL patterns, label-based selectors) because SPA templates can vary by sub-department.
+- Pagination is handled by iterating a `Next` locator until disabled.
+- District/taluka values are extracted from dynamic `<select>` option lists and expanded in parallel.
+
+## API-first strategy
+- All scheme detail URLs are first attempted through `httpx` JSON calls.
+- If JSON parsing fails, scraper falls back to HTML parser.
+- Captured API-like responses are saved to `api_hints.jsonl` to speed payload reverse-engineering and replacement with direct API calls.
+
+## Auth/captcha limitations
+- If captcha or authenticated sessions are required, non-interactive bypass is intentionally not attempted.
+- In that case, use authenticated API tokens/cookies provided by platform operators.

--- a/python_scraper/requirements.txt
+++ b/python_scraper/requirements.txt
@@ -1,0 +1,5 @@
+playwright==1.52.0
+httpx==0.28.1
+python-dotenv==1.1.0
+beautifulsoup4==4.13.4
+tqdm==4.67.1

--- a/python_scraper/src/mahitikanaja_scraper/__init__.py
+++ b/python_scraper/src/mahitikanaja_scraper/__init__.py
@@ -1,0 +1,4 @@
+"""Mahiti Kanaja scraper package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/python_scraper/src/mahitikanaja_scraper/api_client.py
+++ b/python_scraper/src/mahitikanaja_scraper/api_client.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+from .rate_limiter import AsyncRateLimiter
+
+logger = logging.getLogger(__name__)
+
+
+class ApiClient:
+    def __init__(
+        self,
+        timeout: float,
+        max_retries: int,
+        retry_backoff_seconds: float,
+        limiter: AsyncRateLimiter,
+        user_agent: str,
+    ) -> None:
+        self.max_retries = max_retries
+        self.retry_backoff_seconds = retry_backoff_seconds
+        self.limiter = limiter
+        self.client = httpx.AsyncClient(
+            timeout=timeout,
+            headers={"User-Agent": user_agent, "Accept": "application/json, text/html"},
+        )
+
+    async def get_json(self, url: str, params: dict[str, Any] | None = None) -> Any:
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                await self.limiter.wait()
+                response = await self.client.get(url, params=params)
+                response.raise_for_status()
+                return response.json()
+            except Exception as exc:
+                if attempt == self.max_retries:
+                    raise
+                sleep_for = self.retry_backoff_seconds * attempt
+                logger.warning("Retrying %s after error: %s", url, exc)
+                await asyncio.sleep(sleep_for)
+
+    async def get_text(self, url: str, params: dict[str, Any] | None = None) -> str:
+        for attempt in range(1, self.max_retries + 1):
+            try:
+                await self.limiter.wait()
+                response = await self.client.get(url, params=params)
+                response.raise_for_status()
+                return response.text
+            except Exception as exc:
+                if attempt == self.max_retries:
+                    raise
+                sleep_for = self.retry_backoff_seconds * attempt
+                logger.warning("Retrying %s after error: %s", url, exc)
+                await asyncio.sleep(sleep_for)
+
+    async def close(self) -> None:
+        await self.client.aclose()

--- a/python_scraper/src/mahitikanaja_scraper/browser_client.py
+++ b/python_scraper/src/mahitikanaja_scraper/browser_client.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+
+from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class SchemeHandle:
+    name: str
+    detail_url: str
+
+
+class BrowserDiscovery:
+    def __init__(self, base_url: str, headless: bool, user_agent: str) -> None:
+        self.base_url = base_url
+        self.headless = headless
+        self.user_agent = user_agent
+        self._playwright = None
+        self._browser: Browser | None = None
+        self._context: BrowserContext | None = None
+        self.page: Page | None = None
+        self.captured_api_calls: list[tuple[str, str | None]] = []
+
+    async def __aenter__(self) -> "BrowserDiscovery":
+        self._playwright = await async_playwright().start()
+        self._browser = await self._playwright.chromium.launch(headless=self.headless)
+        self._context = await self._browser.new_context(user_agent=self.user_agent)
+        self.page = await self._context.new_page()
+
+        async def _capture(response):
+            url = response.url
+            if "/api" in url.lower() or "scheme" in url.lower() or "department" in url.lower():
+                body = None
+                try:
+                    body = await response.text() if "application/json" in response.headers.get("content-type", "") else None
+                except Exception:
+                    body = None
+                self.captured_api_calls.append((url, body))
+
+        self.page.on("response", _capture)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._context:
+            await self._context.close()
+        if self._browser:
+            await self._browser.close()
+        if self._playwright:
+            await self._playwright.stop()
+
+    async def open_home(self) -> None:
+        assert self.page
+        await self.page.goto(self.base_url, wait_until="domcontentloaded")
+        await self.page.wait_for_load_state("networkidle")
+
+    async def discover_sub_departments(self) -> list[tuple[str, str, str]]:
+        """Return tuples of (department, sub_department, url)."""
+        assert self.page
+        results: list[tuple[str, str, str]] = []
+
+        # Dynamic DOM note: many SPA pages only render cards after JS API calls complete,
+        # so we wait for network idle and query multiple candidate selectors.
+        await self.page.wait_for_load_state("networkidle")
+        selectors = ["a[href*='subdepartment']", ".sub-department a", "a:has-text('Sub Department')"]
+        handles = []
+        for selector in selectors:
+            handles = await self.page.query_selector_all(selector)
+            if handles:
+                break
+
+        for a in handles:
+            title = (await a.inner_text()).strip() or "Unknown"
+            href = await a.get_attribute("href") or ""
+            if href and not href.startswith("http"):
+                href = self.base_url.rstrip("/") + "/" + href.lstrip("/")
+            department = "Unknown Department"
+            results.append((department, title, href))
+        return list({(d, s, u) for d, s, u in results if u})
+
+    async def discover_schemes(self, sub_department_url: str) -> list[SchemeHandle]:
+        assert self.page
+        await self.page.goto(sub_department_url, wait_until="domcontentloaded")
+        await self.page.wait_for_load_state("networkidle")
+        schemes: list[SchemeHandle] = []
+
+        next_button = self.page.locator("button:has-text('Next'), a:has-text('Next')")
+        while True:
+            items = self.page.locator("a[href*='scheme'], .scheme-card a, .scheme-list a")
+            count = await items.count()
+            for idx in range(count):
+                node = items.nth(idx)
+                name = (await node.inner_text()).strip() or f"Scheme-{idx + 1}"
+                href = await node.get_attribute("href") or ""
+                if href and not href.startswith("http"):
+                    href = self.base_url.rstrip("/") + "/" + href.lstrip("/")
+                if href:
+                    schemes.append(SchemeHandle(name=name, detail_url=href))
+
+            if await next_button.count() and await next_button.first.is_enabled():
+                await next_button.first.click()
+                await self.page.wait_for_load_state("networkidle")
+            else:
+                break
+        deduped = {(s.name, s.detail_url): s for s in schemes}
+        return list(deduped.values())
+
+    async def extract_dropdown_values(self, scheme_url: str) -> tuple[list[str], list[str]]:
+        assert self.page
+        await self.page.goto(scheme_url, wait_until="domcontentloaded")
+        await self.page.wait_for_load_state("networkidle")
+
+        districts = []
+        talukas = []
+        district_select = self.page.locator("select[name*='district'], select#district")
+        taluka_select = self.page.locator("select[name*='taluka'], select[name*='taluk'], select#taluka")
+
+        if await district_select.count():
+            options = district_select.first.locator("option")
+            for i in range(await options.count()):
+                text = (await options.nth(i).inner_text()).strip()
+                if text and "select" not in text.lower():
+                    districts.append(text)
+        if await taluka_select.count():
+            options = taluka_select.first.locator("option")
+            for i in range(await options.count()):
+                text = (await options.nth(i).inner_text()).strip()
+                if text and "select" not in text.lower():
+                    talukas.append(text)
+
+        return districts, talukas
+
+    def export_api_hints(self) -> list[str]:
+        hints = []
+        for url, body in self.captured_api_calls:
+            entry = {"url": url}
+            if body:
+                try:
+                    entry["sample"] = json.loads(body)
+                except Exception:
+                    entry["sample"] = body[:500]
+            hints.append(json.dumps(entry, ensure_ascii=False))
+        return hints

--- a/python_scraper/src/mahitikanaja_scraper/cli.py
+++ b/python_scraper/src/mahitikanaja_scraper/cli.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import asyncio
+
+from .config import build_parser, load_config
+from .logging_config import setup_logging
+from .scraper import MahitiKanajaScraper, dump_config_snapshot
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    cfg = load_config(args)
+    setup_logging()
+    dump_config_snapshot(cfg)
+    asyncio.run(MahitiKanajaScraper(cfg).run())
+
+
+if __name__ == "__main__":
+    main()

--- a/python_scraper/src/mahitikanaja_scraper/config.py
+++ b/python_scraper/src/mahitikanaja_scraper/config.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+
+@dataclass(slots=True)
+class ScraperConfig:
+    base_url: str
+    output_dir: Path
+    headless: bool
+    department: str | None
+    district: str | None
+    output_format: str
+    request_timeout: float
+    max_retries: int
+    retry_backoff_seconds: float
+    rate_limit_per_second: float
+    max_parallel_districts: int
+    sqlite_path: Path | None
+    user_agent_pool_path: Path | None
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Mahiti Kanaja scraper")
+    parser.add_argument("--department", help="Scrape only one department", default=None)
+    parser.add_argument("--district", help="Scrape only one district", default=None)
+    parser.add_argument("--headless", action="store_true", help="Run browser in headless mode")
+    parser.add_argument(
+        "--output-format",
+        choices=["json", "csv", "both"],
+        default="both",
+        help="Output data format",
+    )
+    parser.add_argument("--output-dir", default="data", help="Output root folder")
+    parser.add_argument("--sqlite-path", default="data/schemes.db", help="SQLite database path")
+    parser.add_argument("--max-parallel-districts", type=int, default=4)
+    return parser
+
+
+def load_config(args: argparse.Namespace) -> ScraperConfig:
+    load_dotenv()
+    output_dir = Path(args.output_dir)
+    sqlite_path = Path(args.sqlite_path) if args.sqlite_path else None
+    return ScraperConfig(
+        base_url=os.getenv("BASE_URL", "https://mahitikanaja.karnataka.gov.in"),
+        output_dir=output_dir,
+        headless=args.headless or os.getenv("HEADLESS", "true").lower() == "true",
+        department=args.department,
+        district=args.district,
+        output_format=args.output_format,
+        request_timeout=float(os.getenv("REQUEST_TIMEOUT", "30")),
+        max_retries=int(os.getenv("MAX_RETRIES", "3")),
+        retry_backoff_seconds=float(os.getenv("RETRY_BACKOFF_SECONDS", "1.5")),
+        rate_limit_per_second=float(os.getenv("RATE_LIMIT_PER_SECOND", "2.0")),
+        max_parallel_districts=args.max_parallel_districts,
+        sqlite_path=sqlite_path,
+        user_agent_pool_path=Path(os.getenv("USER_AGENT_FILE", "user_agents.txt")),
+    )

--- a/python_scraper/src/mahitikanaja_scraper/logging_config.py
+++ b/python_scraper/src/mahitikanaja_scraper/logging_config.py
@@ -1,0 +1,8 @@
+import logging
+
+
+def setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    )

--- a/python_scraper/src/mahitikanaja_scraper/models.py
+++ b/python_scraper/src/mahitikanaja_scraper/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass(slots=True)
+class SchemeRecord:
+    department_name: str
+    sub_department_name: str
+    scheme_name: str
+    scheme_description: str = ""
+    eligibility_criteria: str = ""
+    required_documents: str = ""
+    benefits: str = ""
+    district: str = ""
+    taluka: str = ""
+    application_mode: str = ""
+    official_links: list[str] = field(default_factory=list)
+
+    def dedupe_key(self) -> tuple[str, str, str, str, str]:
+        return (
+            self.department_name.casefold(),
+            self.sub_department_name.casefold(),
+            self.scheme_name.casefold(),
+            self.district.casefold(),
+            self.taluka.casefold(),
+        )
+
+    def to_dict(self) -> dict:
+        data = asdict(self)
+        data["official_links"] = list(dict.fromkeys(self.official_links))
+        return data

--- a/python_scraper/src/mahitikanaja_scraper/parser.py
+++ b/python_scraper/src/mahitikanaja_scraper/parser.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from bs4 import BeautifulSoup
+
+from .models import SchemeRecord
+
+
+class SchemeParser:
+    @staticmethod
+    def from_api_payload(payload: Mapping, department: str, sub_department: str) -> SchemeRecord:
+        return SchemeRecord(
+            department_name=department,
+            sub_department_name=sub_department,
+            scheme_name=str(payload.get("schemeName") or payload.get("name") or "Unknown Scheme"),
+            scheme_description=str(payload.get("description") or ""),
+            eligibility_criteria=str(payload.get("eligibility") or payload.get("eligibilityCriteria") or ""),
+            required_documents=str(payload.get("documents") or payload.get("requiredDocuments") or ""),
+            benefits=str(payload.get("benefits") or ""),
+            district=str(payload.get("district") or ""),
+            taluka=str(payload.get("taluka") or payload.get("taluk") or ""),
+            application_mode=str(payload.get("applicationMode") or ""),
+            official_links=[str(link) for link in payload.get("officialLinks", []) if link],
+        )
+
+    @staticmethod
+    def from_scheme_detail_html(html: str, department: str, sub_department: str, scheme_name: str) -> SchemeRecord:
+        soup = BeautifulSoup(html, "html.parser")
+
+        def by_label(label: str) -> str:
+            lbl = soup.find(string=lambda s: s and label.lower() in s.strip().lower())
+            if not lbl:
+                return ""
+            parent = lbl.find_parent()
+            if not parent:
+                return ""
+            sibling_text = " ".join(parent.stripped_strings)
+            return sibling_text.replace(label, "").strip(" :")
+
+        links = [a.get("href") for a in soup.select("a[href]") if a.get("href")]
+        return SchemeRecord(
+            department_name=department,
+            sub_department_name=sub_department,
+            scheme_name=scheme_name,
+            scheme_description=by_label("Description"),
+            eligibility_criteria=by_label("Eligibility"),
+            required_documents=by_label("Documents"),
+            benefits=by_label("Benefits"),
+            application_mode=by_label("Application Mode"),
+            official_links=links,
+        )

--- a/python_scraper/src/mahitikanaja_scraper/rate_limiter.py
+++ b/python_scraper/src/mahitikanaja_scraper/rate_limiter.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import asyncio
+import time
+
+
+class AsyncRateLimiter:
+    def __init__(self, per_second: float) -> None:
+        self.interval = 1 / max(per_second, 0.1)
+        self._lock = asyncio.Lock()
+        self._last = 0.0
+
+    async def wait(self) -> None:
+        async with self._lock:
+            now = time.monotonic()
+            delta = now - self._last
+            if delta < self.interval:
+                await asyncio.sleep(self.interval - delta)
+            self._last = time.monotonic()

--- a/python_scraper/src/mahitikanaja_scraper/scraper.py
+++ b/python_scraper/src/mahitikanaja_scraper/scraper.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import urllib.robotparser
+from pathlib import Path
+from urllib.parse import urljoin
+
+from tqdm.asyncio import tqdm
+
+from .api_client import ApiClient
+from .browser_client import BrowserDiscovery
+from .config import ScraperConfig
+from .models import SchemeRecord
+from .parser import SchemeParser
+from .rate_limiter import AsyncRateLimiter
+from .state import ResumeState
+from .storage import StorageManager
+from .ua import UserAgentRotator
+
+logger = logging.getLogger(__name__)
+
+
+class MahitiKanajaScraper:
+    def __init__(self, cfg: ScraperConfig) -> None:
+        self.cfg = cfg
+        self.state = ResumeState(cfg.output_dir / "resume_state.json")
+        self.storage = StorageManager(cfg.output_dir, cfg.output_format, cfg.sqlite_path)
+        self.ua_rotator = UserAgentRotator(cfg.user_agent_pool_path)
+        self.limiter = AsyncRateLimiter(cfg.rate_limit_per_second)
+
+    async def run(self) -> None:
+        user_agent = self.ua_rotator.pick()
+        self._assert_robots_allowed(user_agent)
+
+        api = ApiClient(
+            timeout=self.cfg.request_timeout,
+            max_retries=self.cfg.max_retries,
+            retry_backoff_seconds=self.cfg.retry_backoff_seconds,
+            limiter=self.limiter,
+            user_agent=user_agent,
+        )
+
+        try:
+            async with BrowserDiscovery(self.cfg.base_url, self.cfg.headless, user_agent) as browser:
+                await browser.open_home()
+                sub_depts = await browser.discover_sub_departments()
+                if self.cfg.department:
+                    sub_depts = [x for x in sub_depts if self.cfg.department.casefold() in x[0].casefold()]
+
+                for department, sub_department, sub_url in tqdm(sub_depts, desc="Sub-departments"):
+                    await self._scrape_sub_department(browser, api, department, sub_department, sub_url)
+
+                hints_path = self.cfg.output_dir / "api_hints.jsonl"
+                hints_path.write_text("\n".join(browser.export_api_hints()), encoding="utf-8")
+        finally:
+            await api.close()
+
+    def _assert_robots_allowed(self, user_agent: str) -> None:
+        robots_url = urljoin(self.cfg.base_url.rstrip("/") + "/", "robots.txt")
+        rp = urllib.robotparser.RobotFileParser()
+        rp.set_url(robots_url)
+        rp.read()
+        if not rp.can_fetch(user_agent, self.cfg.base_url):
+            raise PermissionError(f"Scraping blocked by robots.txt for {self.cfg.base_url}")
+
+    async def _scrape_sub_department(self, browser: BrowserDiscovery, api: ApiClient, department: str, sub_department: str, sub_url: str) -> None:
+        schemes = await browser.discover_schemes(sub_url)
+        for scheme in tqdm(schemes, desc=f"Schemes:{sub_department}", leave=False):
+            key = f"{department}|{sub_department}|{scheme.detail_url}"
+            if self.state.is_done(key):
+                continue
+
+            record = await self._fetch_scheme_detail(api, department, sub_department, scheme.name, scheme.detail_url)
+            if not record:
+                continue
+
+            districts, talukas = await browser.extract_dropdown_values(scheme.detail_url)
+            districts = [d for d in districts if not self.cfg.district or self.cfg.district.casefold() in d.casefold()]
+            await self._expand_geographies(record, districts, talukas)
+            self.state.mark_done(key)
+
+    async def _fetch_scheme_detail(
+        self,
+        api: ApiClient,
+        department: str,
+        sub_department: str,
+        scheme_name: str,
+        detail_url: str,
+    ) -> SchemeRecord | None:
+        # Prefer direct API calls where possible. If JSON isn't returned, fallback to HTML parsing.
+        try:
+            payload = await api.get_json(detail_url)
+            if isinstance(payload, dict):
+                return SchemeParser.from_api_payload(payload, department, sub_department)
+            if isinstance(payload, list) and payload:
+                return SchemeParser.from_api_payload(payload[0], department, sub_department)
+        except Exception:
+            logger.info("JSON endpoint not available for %s, parsing HTML", detail_url)
+
+        try:
+            html = await api.get_text(detail_url)
+            return SchemeParser.from_scheme_detail_html(html, department, sub_department, scheme_name)
+        except Exception as exc:
+            logger.error("Failed scheme detail extraction for %s: %s", detail_url, exc)
+            return None
+
+    async def _expand_geographies(self, base_record: SchemeRecord, districts: list[str], talukas: list[str]) -> None:
+        sem = asyncio.Semaphore(self.cfg.max_parallel_districts)
+
+        async def _persist(district: str, taluka: str) -> None:
+            async with sem:
+                clone = SchemeRecord(**base_record.to_dict())
+                clone.district = district
+                clone.taluka = taluka
+                self.storage.persist(clone)
+
+        tasks = []
+        if not districts:
+            self.storage.persist(base_record)
+            return
+
+        for district in districts:
+            if talukas:
+                for taluka in talukas:
+                    tasks.append(_persist(district, taluka))
+            else:
+                tasks.append(_persist(district, ""))
+
+        await asyncio.gather(*tasks)
+
+
+def dump_config_snapshot(cfg: ScraperConfig) -> None:
+    snapshot = {
+        "base_url": cfg.base_url,
+        "headless": cfg.headless,
+        "department": cfg.department,
+        "district": cfg.district,
+        "output_format": cfg.output_format,
+    }
+    (cfg.output_dir / "run_config.json").write_text(json.dumps(snapshot, indent=2), encoding="utf-8")

--- a/python_scraper/src/mahitikanaja_scraper/state.py
+++ b/python_scraper/src/mahitikanaja_scraper/state.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+class ResumeState:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            self.data = json.loads(self.path.read_text())
+        else:
+            self.data = {"completed": []}
+
+    def is_done(self, key: str) -> bool:
+        return key in self.data["completed"]
+
+    def mark_done(self, key: str) -> None:
+        if key not in self.data["completed"]:
+            self.data["completed"].append(key)
+            self.path.write_text(json.dumps(self.data, indent=2))

--- a/python_scraper/src/mahitikanaja_scraper/storage.py
+++ b/python_scraper/src/mahitikanaja_scraper/storage.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import csv
+import json
+import sqlite3
+from pathlib import Path
+
+from .models import SchemeRecord
+
+
+class StorageManager:
+    def __init__(self, output_dir: Path, output_format: str, sqlite_path: Path | None) -> None:
+        self.output_dir = output_dir
+        self.output_format = output_format
+        self.sqlite_path = sqlite_path
+        self._seen: set[tuple[str, str, str, str, str]] = set()
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        if self.sqlite_path:
+            self.sqlite_path.parent.mkdir(parents=True, exist_ok=True)
+            self._init_db()
+
+    def _init_db(self) -> None:
+        with sqlite3.connect(self.sqlite_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schemes (
+                    department_name TEXT,
+                    sub_department_name TEXT,
+                    scheme_name TEXT,
+                    scheme_description TEXT,
+                    eligibility_criteria TEXT,
+                    required_documents TEXT,
+                    benefits TEXT,
+                    district TEXT,
+                    taluka TEXT,
+                    application_mode TEXT,
+                    official_links TEXT,
+                    UNIQUE(department_name, sub_department_name, scheme_name, district, taluka)
+                )
+                """
+            )
+            conn.commit()
+
+    def persist(self, record: SchemeRecord) -> None:
+        key = record.dedupe_key()
+        if key in self._seen:
+            return
+        self._seen.add(key)
+
+        department_folder = self.output_dir / self._safe(record.department_name)
+        department_folder.mkdir(parents=True, exist_ok=True)
+        base = department_folder / self._safe(record.scheme_name)
+        row = record.to_dict()
+
+        if self.output_format in {"json", "both"}:
+            with base.with_suffix(".json").open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+        if self.output_format in {"csv", "both"}:
+            csv_path = base.with_suffix(".csv")
+            write_header = not csv_path.exists()
+            with csv_path.open("a", newline="", encoding="utf-8") as fh:
+                writer = csv.DictWriter(fh, fieldnames=row.keys())
+                if write_header:
+                    writer.writeheader()
+                writer.writerow({**row, "official_links": "|".join(row["official_links"])})
+
+        if self.sqlite_path:
+            with sqlite3.connect(self.sqlite_path) as conn:
+                conn.execute(
+                    """
+                    INSERT OR IGNORE INTO schemes VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record.department_name,
+                        record.sub_department_name,
+                        record.scheme_name,
+                        record.scheme_description,
+                        record.eligibility_criteria,
+                        record.required_documents,
+                        record.benefits,
+                        record.district,
+                        record.taluka,
+                        record.application_mode,
+                        json.dumps(record.official_links, ensure_ascii=False),
+                    ),
+                )
+                conn.commit()
+
+    @staticmethod
+    def _safe(value: str) -> str:
+        return "".join(ch if ch.isalnum() or ch in {"-", "_"} else "_" for ch in value).strip("_") or "unknown"

--- a/python_scraper/src/mahitikanaja_scraper/ua.py
+++ b/python_scraper/src/mahitikanaja_scraper/ua.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import random
+from pathlib import Path
+
+DEFAULT_USER_AGENTS = [
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15",
+]
+
+
+class UserAgentRotator:
+    def __init__(self, user_agent_file: Path | None = None) -> None:
+        self._pool = DEFAULT_USER_AGENTS.copy()
+        if user_agent_file and user_agent_file.exists():
+            custom = [line.strip() for line in user_agent_file.read_text().splitlines() if line.strip()]
+            if custom:
+                self._pool = custom
+
+    def pick(self) -> str:
+        return random.choice(self._pool)

--- a/python_scraper/user_agents.txt
+++ b/python_scraper/user_agents.txt
@@ -1,0 +1,3 @@
+Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36
+Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:124.0) Gecko/20100101 Firefox/124.0
+Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.4 Safari/605.1.15


### PR DESCRIPTION
### Motivation

- Provide a production-grade, modular scraper for https://mahitikanaja.karnataka.gov.in that can navigate SPA pages, enumerate sub-departments and schemes, and export structured scheme/district/taluka data. 
- Prefer an API-first approach (capture network calls and use `httpx` when possible) while retaining Playwright-based HTML fallback for dynamic content. 
- Include reliability and operational features required for long runs: resume capability, rate limiting, user-agent rotation, retries, deduplication, and optional SQLite persistence.

### Description

- Add a new `python_scraper/` project implementing an async Playwright discovery layer (`browser_client.py`), an `httpx` API client with retries (`api_client.py`), HTML/JSON parsing (`parser.py`), a `SchemeRecord` model (`models.py`), and persistence with JSON/CSV/SQLite and dedupe logic (`storage.py`).
- Implement orchestration and operational features in `scraper.py` including robots.txt enforcement, resume state (`state.py`), async rate limiting (`rate_limiter.py`), user-agent rotation (`ua.py`), semaphore-controlled parallel district/taluka expansion, and progress bars via `tqdm`.
- Add CLI and config support (`cli.py`, `config.py`, `.env.example`) with filters `--department`/`--district`, headless mode, and output format options, plus a `Dockerfile`, `requirements.txt`, `user_agents.txt`, and `README.md` documenting setup and dynamic DOM handling choices.
- Include API-hint capture to persist observed API responses for easier endpoint reverse-engineering and an API-first fallback strategy that attempts JSON endpoints before HTML parsing.

### Testing

- `python3 -m compileall python_scraper/src` ran successfully and all modules compiled without syntax errors. 
- `pip3 install -r python_scraper/requirements.txt` completed successfully and required packages were installed. 
- `PYTHONPATH=python_scraper/src python3 -m mahitikanaja_scraper.cli --help` executed successfully and printed the CLI help as expected. 
- `curl -s https://mahitikanaja.karnataka.gov.in/robots.txt | head -n 80` timed out from the CI/network environment and therefore robots.txt could not be validated in this run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996e8a75d90832aa3aeb9c000386811)