### PR TITLE
Fix crash when output directory is missing

### DIFF
--- a/python_scraper/src/mahitikanaja_scraper/scraper.py
+++ b/python_scraper/src/mahitikanaja_scraper/scraper.py
@@ -139,4 +139,5 @@ def dump_config_snapshot(cfg: ScraperConfig) -> None:
         "district": cfg.district,
         "output_format": cfg.output_format,
     }
+    cfg.output_dir.mkdir(parents=True, exist_ok=True)
     (cfg.output_dir / "run_config.json").write_text(json.dumps(snapshot, indent=2), encoding="utf-8")


### PR DESCRIPTION
### Motivation
- Prevent a startup `FileNotFoundError` when the configured output directory does not exist by ensuring the scraper creates the directory before writing its runtime config snapshot.

### Description
- In `dump_config_snapshot` ensure `cfg.output_dir` exists by calling `cfg.output_dir.mkdir(parents=True, exist_ok=True)` before writing `run_config.json`.

### Testing
- Installed project dependencies with `pip install -r python_scraper/requirements.txt` and executed a small Python check that constructs a `ScraperConfig` with a non-existent temp output directory and calls `dump_config_snapshot`, which returned `True` for the presence of `run_config.json` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997116a4b8c832ab62b1f713a026e59)